### PR TITLE
Fix to allow ordering of status columns

### DIFF
--- a/src/routes/professor.js
+++ b/src/routes/professor.js
@@ -165,38 +165,65 @@ module.exports = function(app, utils, application, fns) {
 		sqlCol += 'app_Id, CONCAT_WS(\' \', `FName`, `LName`) AS `Applicant Name`, ' +
 		'Gender, FOI as `Fields of Interest`, prefProfs as `Preferred Professors`, ' +
 		'Rank as `Committee Rank`, GPA, Degree as `Degree Applied For`,' +
-		' VStatus as `Visa Status`, programDecision as `Program Decision`,';
+		' VStatus as `Visa Status`, programDecision as `Program Decision`, ' + 
+		'profContacted as `Contacted By`, profRequested as `Requested By`, ' + 
+		'seen as `My Interest Status` ';
 
 		/* build columns */
 		if (cols) {
+			sqlCol = 'app_Id, ';
 			for (var i = 0; i < cols.length; i++) {
-				if (i === 0)
-					sqlCol = 'app_Id, ';
-
 				if (cols[i] === 'btn_col_name') {
-					sqlCol += 'CONCAT_WS(\' \', `FName`, `LName`) AS `Applicant Name`,';
+					sqlCol += 'CONCAT_WS(\' \', `FName`, `LName`) AS `Applicant Name`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_gender') {
-					sqlCol += 'Gender,';
+					sqlCol += 'Gender';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_foi') {
-					sqlCol += 'FOI as `Fields of Interest`,';
+					sqlCol += 'FOI as `Fields of Interest`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_prof') {
-					sqlCol += 'prefProfs as `Preferred Professors`,';
+					sqlCol += 'prefProfs as `Preferred Professors`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_ranking') {
-					sqlCol += 'Rank as `Committee Rank`,';
+					sqlCol += 'Rank as `Committee Rank`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_gpa') {
-					sqlCol += 'GPA,';
+					sqlCol += 'GPA';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_degree') {
-					sqlCol += 'Degree as `Degree Applied For`,';
+					sqlCol += 'Degree as `Degree Applied For`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_visa') {
-					sqlCol += 'VStatus as `Visa Status`,';
+					sqlCol += 'VStatus as `Visa Status`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_program_decision') {
-					sqlCol += 'programDecision as `Program Decision`,';
+					sqlCol += 'programDecision as `Program Decision`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_contacted_status') {
 					contactedField = true;
+					sqlCol += 'profContacted as `Contacted By`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_requested_status') {
 					requestedField = true;
+					sqlCol += 'profRequested as `Requested By`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_interest') {
 					interestField = true;
+					sqlCol += 'seen as `My Interest Status`';
+					if (i < cols.length - 1)
+						sqlCol += ', '; 
 				} else if (cols[i] === 'btn_col_actions') {
 					actionFieldNum = i + 1; // offset of the appId
 				}
@@ -308,10 +335,8 @@ module.exports = function(app, utils, application, fns) {
 		}
 
 		function proceed() {
-			sql += sqlCol + 'profContacted as `Contacted By`, profRequested as ' +
-			'`Requested By`, seen as `My Interest Status` FROM APPLICATION' +
-			joinSql + ' WHERE committeeReviewed=1 and Rank is not null' +
-			sqlFilt;
+			sql += sqlCol + ' FROM APPLICATION' + joinSql + 
+			' WHERE committeeReviewed=1 and Rank is not null' + sqlFilt;
 
 			var options = {
 				actionFieldNum: actionFieldNum,

--- a/src/test/specs/unit/professor.test.js
+++ b/src/test/specs/unit/professor.test.js
@@ -1442,6 +1442,80 @@ describe('Professor Test', function() {
 					.then(expect(prof.tableBodyExists.call(prof)).to.eventually.be.false)
 					.then(expect(prof.getTableError.call(prof)).to.eventually.contain('Error loading table.'));
 			});
+
+			it('- order status columns', function() {
+				filter.openFilterModal().then(filter.waitForModalOpen.call(filter))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.applicant))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.crank))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.gpa))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.foi))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.interested))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.contacted))
+					.then(filter.toggleColumn.call(filter, filter.filter.cols.requested))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.applicant.index)).to
+						.eventually.contain('1'))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.crank.index)).to
+						.eventually.contain('2'))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.gpa.index)).to
+						.eventually.contain('3'))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.foi.index)).to
+						.eventually.contain('4'))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.interested.index)).to
+						.eventually.contain('5'))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.contacted.index)).to
+						.eventually.contain('6'))
+					.then(expect(filter.getColumnIndex.call(filter, filter.filter.cols.requested.index)).to
+						.eventually.contain('7'))
+					.then(expect(filter.columnIsSelected.call(filter, 'Name'))
+						.to.eventually.be.true)
+					.then(expect(filter.columnIsSelected.call(filter, 'Committee Ranking'))
+						.to.eventually.be.true)
+					.then(expect(filter.columnIsSelected.call(filter, 'GPA'))
+						.to.eventually.be.true)
+					.then(expect(filter.columnIsSelected.call(filter, 'Fields of Interest'))
+						.to.eventually.be.true)
+					.then(expect(filter.columnIsSelected.call(filter, 'My Interest Status'))
+						.to.eventually.be.true)
+					.then(expect(filter.columnIsSelected.call(filter, 'Contacted By'))
+						.to.eventually.be.true)
+					.then(expect(filter.columnIsSelected.call(filter, 'Requested By'))
+						.to.eventually.be.true)
+					.then(filter.openFieldDD.call(filter, filter.filter.fields
+						.gpa.openDD))
+					.then(expect(filter.isFieldDDOpen.call(filter, filter.filter
+						.fields.gpa.openDD)).to.eventually.be.true)
+					.then(filter.searchText.call(filter, 'B'))
+					.then(filter.selectIthElement.call(filter, 5))
+					.then(expect(filter.getSelectedElement.call(filter)).to
+						.eventually.contain('> B'))
+					.then(expect(filter.getSelectedFilter.call(filter)).to.eventually
+						.contain('GPA > B'))
+					.then(filter.openFieldDD.call(filter, filter.filter.fields
+						.foi.openDD))
+					.then(expect(filter.isFieldDDOpen.call(filter, filter.filter
+						.fields.foi.openDD)).to
+						.eventually.be.true)
+					.then(filter.searchText.call(filter, 'in'))
+					.then(filter.selectIthElement.call(filter, 1))
+					.then(expect(filter.getSelectedElement.call(filter)).to
+						.eventually.contain('Artificial Intelligence'))
+					.then(expect(filter.getSelectedFilter.call(filter)).to.eventually
+						.contain('Field of Interest = Artificial Intelligence'))
+					.then(filter.submitFilter.call(filter))
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('filter'))
+					.then(expect(prof.applicationTableIsDisplayed.call(prof)).to.eventually.be.true)
+					.then(expect(prof.tableHeaderExists.call(prof)).to.eventually.be.true)
+					.then(expect(prof.tableBodyExists.call(prof)).to.eventually.be.true)
+					.then(expect(prof.getTableColumns.call(prof)).to.eventually.equal(8))
+					.then(expect(prof.getColumnName.call(prof, 0)).to.eventually.equal('Applicant Name'))
+					.then(expect(prof.getColumnName.call(prof, 1)).to.eventually.equal('Committee Rank'))
+					.then(expect(prof.getColumnName.call(prof, 2)).to.eventually.equal('GPA'))
+					.then(expect(prof.getColumnName.call(prof, 3)).to.eventually.equal('Fields of Interest'))
+					.then(expect(prof.getColumnName.call(prof, 4)).to.eventually.equal('My Interest Status'))
+					.then(expect(prof.getColumnName.call(prof, 5)).to.eventually.equal('Contacted By'))
+					.then(expect(prof.getColumnName.call(prof, 6)).to.eventually.equal('Requested By'))
+					.then(expect(prof.getColumnName.call(prof, 7)).to.eventually.equal('Actions'));
+			});
 		});
 	});
 });


### PR DESCRIPTION
closes #40 

# Description

The columns: Contacted By, Requested By, and My Interest Status, whenever selected, is added to the rightmost column of the table no matter which position it is selected. (in that order)

# Acceptance Criteria
- [x] Fix to the bug
- [x] Write unit test