### PR TITLE
Fix assigning review after filtering

### DIFF
--- a/src/routes/admin/manage-app/edit-app.js
+++ b/src/routes/admin/manage-app/edit-app.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
-var async = require('async');
-
 module.exports = function(config, fns) {
 	var app = config.app;
 	var application = config.application;

--- a/src/routes/admin/manage-review.js
+++ b/src/routes/admin/manage-review.js
@@ -24,7 +24,7 @@ module.exports = function(config, fns) {
 
 	// managing review route - GET
 	app.post(route, postEditReviews, function(req, res) {
-		res.redirect(default_route);
+		res.redirect('/roles/admin/reviews/manage?appId=' + appId);
 	});
 
 	function defaultView(req, res)  {

--- a/src/test/specs/unit/app.test.js
+++ b/src/test/specs/unit/app.test.js
@@ -18,7 +18,7 @@ var Welcome = require('../../views/welcome-view');
 
 var config = require('../../lib/utils/config');
 
-describe.only('Manage Applications Test', function() {
+describe('Manage Applications Test', function() {
 	var timeout = ms('60s');
 	this.timeout(timeout);
 

--- a/src/test/specs/unit/review.test.js
+++ b/src/test/specs/unit/review.test.js
@@ -109,18 +109,22 @@ describe('Manage Reviews Test', function() {
 
 	it('- open review manage page', function() {
 		review.manageReview(0)
+			.then(utils.switchTab.call(utils, 1))
 			.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'))
-			.then(review.closeReviewForm.call(review))
+			.then(utils.goToTab.call(utils, 0))
 			.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'));
 	});
 
 	describe('- check for fields', function() {
 		before(function setUp() {
-			review.manageReview(0);
+			review.manageReview(0)
+				.then(utils.switchTab.call(utils, 1))
+				.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'));
 		});
 
 		after(function cleanUp() {
-			review.closeReviewForm();
+			utils.goToTab(0)
+				.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'));
 		});
 
 		describe('- general information section', function() {
@@ -173,35 +177,43 @@ describe('Manage Reviews Test', function() {
 
 		describe('- unassigning a review', function() {
 			before(function setUp() {
-				review.manageReview(appId);
+				review.manageReview(appId)
+					.then(utils.switchTab.call(utils, 1))
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'));
 			});
     
 			after(function cleanUp() {
-				expect(browser.getCurrentUrl()).to.eventually.contain('/reviews')
+				utils.goToTab(0)
+					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'))
+					.then(review.refreshTable.call(review))
 					.then(review.selectReviewer.call(review, appId, cmIndex.first))
 					.then(review.assignReview.call(review, appId));
 			});
 
 			it('- unassign a review', function() {
 				review.unassignReview(unassign)
-					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'));
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'));
 			});
 		});
         
 		describe('- dismissing a review', function() {
 			before(function setUp() {
-				review.manageReview(appId);
+				review.manageReview(appId)
+					.then(utils.switchTab.call(utils, 1))
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'));
 			});
     
 			after(function cleanUp() {
-				expect(browser.getCurrentUrl()).to.eventually.contain('/reviews')
+				utils.goToTab(0)
+					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'))
+					.then(review.refreshTable.call(review))
 					.then(review.selectReviewer.call(review, appId, cmIndex.second))
 					.then(review.assignReview.call(review, appId));
 			});
 
 			it('- unassign a review', function() {
 				review.dismissReview(dismiss)
-					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'));
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'));
 			});
 		});
 	});
@@ -660,7 +672,6 @@ describe('Manage Reviews Test', function() {
 		describe('- apply filtering and assign a review', function() {
 			var unassign;
 			var appIndex = unassign = 0;
-			var regAppIndex = 2;
 			var cmIndex = 1;
 			
 			before(function setUp() {
@@ -716,9 +727,12 @@ describe('Manage Reviews Test', function() {
 						.contain('Field(s) of Interest = Artificial Intelligence'))
 					.then(filter.submitFilter.call(filter))
 					.then(review.manageReview.call(review, appIndex))
+					.then(utils.switchTab.call(utils, 1))
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'))
 					.then(review.unassignReview.call(review, unassign))
-					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'));
-
+					.then(utils.goToTab.call(utils, 0))
+					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'))
+					.then(review.loadDefaultTable.call(review));
 			});
 
 			it('- assign a review after filtering', function() {
@@ -727,25 +741,24 @@ describe('Manage Reviews Test', function() {
 					.then(expect(review.isOptionSelected.call(review, 'Byrom Allbones')).to.eventually.be.true)
 					.then(review.assignReview.call(review, appIndex))
 					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/reviews'))
-					.then(expect(review.getReviewAssigned.call(review, regAppIndex)).to.eventually.contain('2 / 2'))
-					.then(expect(review.getReviewPending.call(review, regAppIndex)).to.eventually.contain('1 / 2'));
+					.then(expect(review.getReviewAssigned.call(review, appIndex)).to.eventually.contain('2 / 2'))
+					.then(expect(review.getReviewPending.call(review, appIndex)).to.eventually.contain('1 / 2'));
 			});
 		});
 
 		describe('- apply filtering and unassign a review', function() {
 			var unassign;
 			var appIndex = unassign = 0;
-			var regAppIndex = 2;
 			var cmIndex = 5;
 			
 			before(function setUp() {
-				expect(review.getReviewAssigned(regAppIndex)).to.eventually.contain('1 / 2')
-					.then(review.selectReviewer.call(review, regAppIndex, cmIndex))
+				expect(review.getReviewAssigned(appIndex)).to.eventually.contain('1 / 2')
+					.then(review.selectReviewer.call(review, appIndex, cmIndex))
 					.then(expect(review.isOptionSelected.call(review, 'Hillier Laville')).to.eventually.be.true)
-					.then(review.assignReview.call(review, regAppIndex))
+					.then(review.assignReview.call(review, appIndex))
 					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/reviews'))
-					.then(expect(review.getReviewAssigned.call(review, regAppIndex)).to.eventually.contain('2 / 2'))
-					.then(expect(review.getReviewPending.call(review, regAppIndex)).to.eventually.contain('1 / 2'))
+					.then(expect(review.getReviewAssigned.call(review, appIndex)).to.eventually.contain('2 / 2'))
+					.then(expect(review.getReviewPending.call(review, appIndex)).to.eventually.contain('1 / 2'))
 					.then(filter.openFilterModal.call(filter))
 					.then(filter.waitForModalOpen.call(filter))
 					.then(filter.openFieldDD.call(filter, filter.filter.fields
@@ -775,16 +788,19 @@ describe('Manage Reviews Test', function() {
 
 			it('- unassign a review after filtering', function() {
 				review.manageReview(appIndex)
+					.then(utils.switchTab.call(utils, 1))
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'))
 					.then(review.unassignReview.call(review, unassign))
+					.then(utils.goToTab.call(utils, 0))
 					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'))
-					.then(expect(review.getReviewAssigned(regAppIndex)).to.eventually.contain('1 / 2'));
+					.then(review.refreshTable.call(review))
+					.then(expect(review.getReviewAssigned(appIndex)).to.eventually.contain('1 / 2'));
 			});
 		});
 
 		describe('- apply filtering and dismiss a review', function() {
 			var dismiss;
 			var appIndex = dismiss = 0;
-			var regAppIndex = 2;
 			
 			before(function setUp() {
 				filter.openFilterModal().then(filter.waitForModalOpen.call(filter))
@@ -815,9 +831,13 @@ describe('Manage Reviews Test', function() {
 
 			it('- dismiss a review after filtering', function() {
 				review.manageReview(appIndex)
+					.then(utils.switchTab.call(utils, 1))
+					.then(expect(browser.getCurrentUrl()).to.eventually.contain('/manage'))
 					.then(review.dismissReview.call(review, dismiss))
+					.then(utils.goToTab.call(utils, 0))
 					.then(expect(browser.getCurrentUrl()).to.eventually.not.contain('/manage'))
-					.then(expect(review.getReviewAssigned(regAppIndex)).to.eventually.contain('0 / 2'));
+					.then(review.refreshTable.call(review))
+					.then(expect(review.getReviewAssigned(appIndex)).to.eventually.contain('0 / 2'));
 			});
 		});
 	});

--- a/src/test/views/manage-review-view.js
+++ b/src/test/views/manage-review-view.js
@@ -14,6 +14,7 @@ function Review(timeout) {
 	this.tables.table.columns = by.css('#table-head > tr > th');
     
 	this.tables.refresh = by.id('refresh-table');
+	this.tables.default = by.id('reset-table');
 
 	this.tables.error = by.id('error-message');
 
@@ -308,6 +309,11 @@ Review.prototype.getRefreshTableText = function() {
 
 Review.prototype.refreshTable = function() {
 	return this.utils.waitForElementClickable(this.tables.refresh, this.timeout)
+		.then(element(this.tables.refresh).click());
+};
+
+Review.prototype.loadDefaultTable = function() {
+	return this.utils.waitForElementClickable(this.tables.default, this.timeout)
 		.then(element(this.tables.refresh).click());
 };
 

--- a/src/views/manage-review.ejs
+++ b/src/views/manage-review.ejs
@@ -106,10 +106,6 @@
                     </div>
                 </div>
             </div>
-
-            <div class="row">
-                <a id="edit-close" href="/roles/admin/reviews/manage" class="btn btn-primary"><span class="glyphicon glyphicon glyphicon-remove-sign"></span> Close</a>
-            </div>
     </div>
     <script src="https://web.archive.org/web/20161124120603js_/http://www.papercut.com/products/free-software/are-you-sure/jquery.are-you-sure.js"></script>
 </body>

--- a/src/views/view-review.ejs
+++ b/src/views/view-review.ejs
@@ -58,7 +58,7 @@
                                                             <%} %>
                                                         <% } else { %>
                                                             <td class="text-center">
-                                                                <form id="review-form-<%=i%>" action="/roles/admin/reviews" method="POST">
+                                                                <form id="review-form-<%=i%>" action=<%= url %> method="POST">
                                                                     <% if(apps[i]['Visa Status'] === 'Domestic' && apps[i]['Reviews Assigned'] != max_dom) { %> 
                                                                         <select id="cms-<%=i%>" name="cms" class="form-control selectpicker" data-live-search="true" title="Pick one or more assignee" multiple data-max-options= <%= max_dom - apps[i]['Reviews Assigned'] %> >
                                                                             <% for(var k = 0; k < cms.length; k++){ %>
@@ -76,7 +76,7 @@
                                                                     <% } %>
                                                                 </form>
                                                                     <% if (apps[i]['Reviews Assigned'] > 0) { %>
-                                                                        <a id="manage-review-<%=i%>" href="/roles/admin/reviews/manage?appId=<%= apps[i][fields[0]]%>" class="btn btn-primary" style="margin-bottom: 5px">Manage Reviews &raquo;</a></li>
+                                                                        <a id="manage-review-<%=i%>" href="/roles/admin/reviews/manage?appId=<%= apps[i][fields[0]]%>" target="_blank" class="btn btn-primary" style="margin-bottom: 5px">Manage Reviews &raquo;</a></li>
                                                                     <% } %>
                                                                     <a id="view-app-<%=i%>" href="/roles/admin/reviews/view?appId=<%= apps[i][fields[0]] %>" target="_blank" class="btn btn-primary" style="margin-bottom: 5px">View Application PDF &raquo;</a></li>
                                                             </td>


### PR DESCRIPTION
# Description

Assigning reviews after filtering would go back to the default table view. Fix includes redirecting back to the filtered set of tables only.

# Acceptance Criteria
- [x] Fix to show the filtered data after assigning review on a filtered set of reviews
- [x] Fix test cases